### PR TITLE
disabled cache on epoch

### DIFF
--- a/typescript-wallet/src/clients/gateway-client.ts
+++ b/typescript-wallet/src/clients/gateway-client.ts
@@ -17,6 +17,7 @@ export const GatewayClient = (networkConfig: NetworkConfig) => {
     applicationName: 'dApp mgmt',
     headers: {
       "Cache-Control": "no-cache",
+      cache: "no-store",
     },
   })
 

--- a/typescript-wallet/src/clients/gateway-client.ts
+++ b/typescript-wallet/src/clients/gateway-client.ts
@@ -15,6 +15,9 @@ export const GatewayClient = (networkConfig: NetworkConfig) => {
   const { status, transaction, state } = GatewayApiClient.initialize({
     basePath: networkConfig.gatewayUrl,
     applicationName: 'dApp mgmt',
+    headers: {
+      "Cache-Control": "no-cache",
+    },
   })
 
   const wellKnownAddresses = () =>


### PR DESCRIPTION
epoch request gets cached and transactions will fail because of this ... when disabling cache the epoch will be calculated on every transaction build